### PR TITLE
Adding Howto-update-teia-docs.md guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## [Teia Wiki](https://github.com/teia-community/teia-docs/wiki)
 
-You can edit the wiki if you are a member of the Teia-Community organization
-using the GitHub inteface above or by editing the files in the /wiki directory
+You can edit the [wiki](https://github.com/teia-community/teia-docs/wiki) if you are a member of the Teia-Community organization
+using the GitHub wiki inteface or by editing the files in the [/wiki](https://github.com/teia-community/teia-docs/tree/main/wiki) directory
 of this repo.  Optionally, when you edit the files in the /wiki directory, you
 can create a PR and colloborate with others to review the change.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -38,6 +38,9 @@ find out how to [get started with Tezos](https://github.com/teia-community/teia-
 
 ***
 ## Something missing? Found an error in the wiki?
+
+* [[Howto-update-teia-docs]]
+
 While the site is being actively worked on by the community, we aim to keep this wiki in sync and up to date with the latest features. Please keep in mind that Teia run by contributors who work on a volunteer basis. If something doesn’t make sense, if you would like to see new content, or if you want to contribute, please submit a [issue report here](https://github.com/teia-community/teia-docs/issues) or come to the [Discord](https://discord.gg/JV2ehAn2).
 
 ***

--- a/wiki/Howto-update-teia-docs.md
+++ b/wiki/Howto-update-teia-docs.md
@@ -1,13 +1,8 @@
 ## Update Documentation in the Teia Docs Repository
 
-This guide provides step-by-step instructions on how to update a documentation file stored in the /wiki folder of this GitHub repository. The process involves navigating to the file, accessing the editing interface, and making changes using the built-in Markdown editor.
+This guide provides instructions on how to update a documentation file stored in the /wiki folder of this GitHub repository.
 
-Note that formerly files were stored in the wiki repo of this, the Teia Docs repository, but they have now been moved to the /wiki folder.  When you edit a file in the /wiki folder on the main branch, a GitHub action will be triggered and that file will be pushed to the internal GitHub wiki repo.  Likewise when any update is made using the GitHub wiki interface, that changed will be synced back to the /wiki folder.  This is only temporary until we have decied on another publishing workflow for our documentation using a tool like Docusaurus or Tinacms.
-
-Eventually this documentation, this page you are reading now, describing how to update the
-documentation, will be stored in the GitHub wiki for this repo, the Teia Docs
-repo. Along with maybe a few other pages which explain what the Teia Docs repo
-is for, how to update the documentation, and how to manage the documentation tools we decide to use.
+Note that formerly files were stored in the "internal wiki repo" of this, the Teia Docs repository, but they have now been moved to the /wiki folder.  When you edit a file in the /wiki folder on the main branch, a GitHub action will be triggered to push the change to the internal GitHub wiki repo.  Likewise when any update is made using the GitHub wiki interface, that change will be synced back to the /wiki folder.
 
 ## For Teia Organization members
 
@@ -43,4 +38,4 @@ Docs repository.
 Once you have your own fork, proceed to make the changes or updates you wish to
 make then commit your changes to your fork and issue a Pull Request.
 
-You can even use the wiki editing feature in your fork to edit files, which will be synced back to the main branch of your fork where you can prepare a PR back to the main Teia Docs repo. 
+You can even use the wiki editing feature in your fork to edit files, which will be synced back to the main branch of your fork where you can then prepare a PR back to the main Teia Docs repo. 

--- a/wiki/Howto-update-teia-docs.md
+++ b/wiki/Howto-update-teia-docs.md
@@ -27,7 +27,7 @@ And this will help you create a new branch and make a PR with a "Propose Changes
 
 ### I want to create a new page
 
-Use the wiki interface, in the code repository browser click the + sign above the file listing on the left side navigation menu and click "Add file", or clone the repository locally and add your file using your terminal or IDE.
+Use the wiki interface, or in the code repository browser click the + sign above the file listing on the left side navigation menu and click "Add file", or clone the repository locally and add your file using your terminal or IDE.
 
 ## For any GitHub user not a member of the Teia Organization
 

--- a/wiki/Howto-update-teia-docs.md
+++ b/wiki/Howto-update-teia-docs.md
@@ -18,15 +18,20 @@ In the future we might adopt another documentation editing tool, but for now thi
 
 ### What if I want to create a PR for the change?
 
-Optionally if you want to create a PR for your update, to to the Teia Docs code repository and find the /wiki folder mentioned above.  You will see a listing of .md files.  Click on the file name of any of those files and you will be taken to a markdown editing interface for that page.  Click the pencil icon to edit the page.  
+Optionally if you want to create a PR for your update, you can go to the [Teia docs code repository](https://github.com/teia-community/teia-docs) and find the [/wiki](https://github.com/teia-community/teia-docs/tree/main/wiki) folder mentioned above.  You will see a listing of .md files.  Click on the file name of any of those files and you will be taken to a markdown editing interface for that page.  Click the pencil icon to edit the page.  You will find that the markdown editor in the code repository, does not have the handy wiki editing toolbar for adding headings, links, images etc... so you might prefer to continue to use the wiki for editing, and the changes you make there will be synced back to the /wiki folder.
 
 ![A screenshot of the code repository browser.](https://raw.githubusercontent.com/teia-community/teia-docs/main/wiki/img/howto_teia_docs/updatedocs.png)
 
-You will find it doesn't have a handy toolbar for editing the file, but you may want to use this interface if you are just making some substantial updates to the text of the document and would like to start a peer review process.  When you have made your edits click the green "Commit changes..." button: 
+You may want to use this interface if you are making some substantial updates to the text of the document and would like to start a peer review process.  When you have made your edits click the green "Commit changes..." button: 
 
 ![Code repository editor screen.](https://raw.githubusercontent.com/teia-community/teia-docs/main/wiki/img/howto_teia_docs/updatedocs2.png)
 
+And this will help you create a new branch and make a PR with a "Propose Changes" dialog box.  Be sure to click the option for "create new branch" and Github will suggest a branch name for you.  
+
+![Screenshot from 2023-06-23 10-42-54](https://github.com/floydwilde/teia-docs/assets/201620/30a608ef-fe15-4e48-93a8-cea4ccac3590)
+
 ### I want to create a new page
+
 Use the wiki interface, in the code repository browser click the + sign above the file listing on the left side navigation menu and click "Add file", or clone the repository locally and add your file using your terminal or IDE.
 
 ## For any GitHub user not a member of the Teia Organization
@@ -37,3 +42,5 @@ Docs repository.
 
 Once you have your own fork, proceed to make the changes or updates you wish to
 make then commit your changes to your fork and issue a Pull Request.
+
+You can even use the wiki editing feature in your fork to edit files, which will be synced back to the main branch of your fork where you can prepare a PR back to the main Teia Docs repo. 


### PR DESCRIPTION
Adding a guide on how to update documentation in the "/wiki" folder which is now synced to the "internal" Github wiki for the Teia Docs repo.  

Discovered a process where you can use the Wiki interface in a fork, and then, once your changes are synced to the main branch of your fork, you can then create a PR (like I have just here) to review the changes.  Noted this on the bottom of the Howto-update-teia-docs.md guide. 
