### PR TITLE
Fix two typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## [Teia Wiki](https://github.com/teia-community/teia-docs/wiki)
 
 You can edit the [wiki](https://github.com/teia-community/teia-docs/wiki) if you are a member of the Teia-Community organization
-using the GitHub wiki inteface or by editing the files in the [/wiki](https://github.com/teia-community/teia-docs/tree/main/wiki) directory
+using the GitHub wiki interface or by editing the files in the [/wiki](https://github.com/teia-community/teia-docs/tree/main/wiki) directory
 of this repo.  Optionally, when you edit the files in the /wiki directory, you
-can create a PR and colloborate with others to review the change.
+can create a PR and collaborate with others to review the change.
 
 Updates to files in the /wiki folder will be published to the wiki and updates
 in the wiki itself will sync changes back to the /wiki folder.


### PR DESCRIPTION
As mentioned in #12, there are many typos in the docs, but putting them in a large PR is difficult to merge.

It's probably simpler if we create smaller PRs like this one.  I know that it is even simpler if we just use the wiki interface to update the documentation for small changes like this, but I wanted to demonstrate how PRs could work if we wanted to use a peer review process for more significant changes in the future.