### PR TITLE
Clean up tools page

### DIFF
--- a/wiki/General-FAQs.md
+++ b/wiki/General-FAQs.md
@@ -1,10 +1,10 @@
 ## I received some tez, so I suppose I sold work. But where do I see which OBJKT I sold?
 
-First of all, congratulations. 
+First of all, congratulations.
 
-You can use the [hictory.glitch.me](https://hictory.glitch.me/) to check your sales, just add your wallet address and you will get a sales history of your NFTs.
+You can check your recent sales activity using your wallet interface (such as [Temple Wallet](https://templewallet.com/)). Click on your tez balance to open the **Activity** tab, which shows incoming and outgoing transactions. For more detail, click on a transaction to view it in a blockchain explorer like [TzKT.io](https://tzkt.io/) or [Better Call Dev](https://better-call.dev/), where you can see which specific OBJKT was transferred or sold.
 
-you can find more selling/notification tools on this [wiki article on community tools](https://github.com/teia-community/teia-docs/wiki/Tools-made-by-the-community#selling-tools)
+For more advanced tools, including notification bots and artist dashboards, see the [Selling Tools section](https://github.com/teia-community/teia-docs/wiki/Tools-made-by-the-community#selling-tools) of the community tools page.
 
 ## How do I get a notification when something sells?
 You can use the telegram notification bot or Cryptonoises bot that we have listed in the [Tools/Selling Tools](https://github.com/teia-community/teia-docs/wiki/Tools-made-by-the-community#selling-tools) section

--- a/wiki/Tools-made-by-the-community.md
+++ b/wiki/Tools-made-by-the-community.md
@@ -1,40 +1,22 @@
-
-Due to the open source nature of Teia/hicetnunc, a lot of tools have been build around the Tezos NFT ecosystem. Here we try to commpile a list of community build tools especially around the OBJKT Token standard. Please note that moost of these tools are experimental and some might not be maintained or use outdated data.
+Due to the open source nature of Teia/hicetnunc, a lot of tools have been built around the Tezos NFT ecosystem. Here we try to compile a list of community built tools especially around the OBJKT Token standard. Please note that most of these tools are experimental and some might not be maintained or use outdated data. Please move defunct tools to the deprecated section at the end of this document. Found a new tool? Please add it to the list.
 
 ## Discovery Tools
 
 * [Teztok Live feed](https://live.teztok.com/) Customizable Tezos NFT Live feed that includes minting, swapping, sales offers across marketplaces.
 
-* [Hen Radio](https://hen.radio/) Browse and enjoy music NFTs minted on Teia/Hicetnunc. By working group 7.2 with [orderandchaos](https://twitter.com/__orderandchaos) , during the first Hicathon. Supports MP3, WAV, and OGG. Can be embedded into any websites. 
-
-* [HEO Catalog](https://heo.zmnv.art/) A catalogue of all .glb/.gltf OBJKTs minted on Hicetnunc/Teia 
-
-* [random artists](https://henstorefront.xyz/) included in henstorefront.xyz by [homeworkpunks](https://twitter.com/homeworkpunks)
-
 * [here or there](https://here-or-there.glitch.me/) a visual map of all OBJKTs by Quasimondo
 
 * [singulare.xyz](https://www.singulare.xyz/) by [Tezos Miami](https://twitter.com/tezosmiami) and [ahamartist](https://twitter.com/ahamartist) - a NFT explorer for 1/1 pieces on Tezos (hicetnunc, Teia, objktcom, versum)
 
-* [fotographia.xyz](https://www.fotographia.xyz/) - a NFT explorer for photographic pieces minted with the hicetnunc minter
+* [fotographia.xyz](https://www.fotographia.xyz/) - a NFT explorer for photographic pieces minted with the hicetnunc minter (seems broken)
 
 ***
 
-
-
-* [Discovery Tool](https://projects.stroep.nl/hicetnunc/v2/#discover), [Filter by tags](https://projects.stroep.nl/hicetnunc/v2/#tags) and [Top creators](https://projects.stroep.nl/hicetnunc/v2/#creators) by Mark Knol **Teia swaps not (yet) supported!**
-
-* [Discover OBJKTs by price tiers](https://hicetnunc.miketyka.com) by Mike Tyka **Teia swaps not (yet) supported!**
-
-
+* [Discovery Tool](https://projects.stroep.nl/hicetnunc/v2/#discover), [Filter by tags](https://projects.stroep.nl/hicetnunc/v2/#tags) and [Top creators](https://projects.stroep.nl/hicetnunc/v2/#creators) by Mark Knol **Teia swaps not (yet) supported!** (also seems broken)
 
 ## Batch operations (Swap, Cancel, send)
 
-* [Order and Chaos tools](https://tools.orderandchaos.xyz/) by [@__orderandchaos](https://twitter.com/__orderandchaos)
- Older tool but now swaps on teia.art.   "Now swaps on Teia instead of H=N.  So… if you still have H=N v1/v2 swaps you could batch cancel, then batch swap on Teia"  The tool also allows you to select multiple from one wallet and send to another wallet.  
-
 * [Batch Unswap/Reswap Tool (open)](https://nftbiker.xyz/swap/reswap) by [NFTBiker](https://twitter.com/NFTBiker) - batch cancel or migrate your swaps from various marketplace contracts.
-
-* [batch minting tool](https://henstorefront.xyz/) included in henstorefront.xyz by [homeworkpunks](https://twitter.com/homeworkpunks)
 
 * [FA2 token batch sender](https://batch.xtz.tools) by [PureSpider](https://twitter.com/PureSpider) - Makes it a lot easier to send lots of tokens to many people at once - no more waiting for your wallet to confirm transactions one by one
 
@@ -42,41 +24,29 @@ Due to the open source nature of Teia/hicetnunc, a lot of tools have been build 
 
 * [mmmints.xyz](https://mmm.mmmints.xyz/) by [secondcass](https://twitter.com/secondcass) - view the newest mints from tezos artists that you've collected (teia, objkt, 8bidou, versum and possibly more). If you collect a lot, you may get a big results page. For Hicetnunc activity only you can use [hennycomp](https://hennycomb.glitch.me/)
 
-* [hic.af](https://hic.af/) by  [Gwendall](https://twitter.com/gwendall) supports following artists 
-
-* [Henext.xyz](www.henext.xyz) by [xfunct](https://twitter.com/xsfunc) supports following artists 
+* [hic.af](https://hic.af/) by  [Gwendall](https://twitter.com/gwendall) supports following artists
 
 ## Selling Tools
 
-* [hictory](https://hictory.glitch.me/) by [Leith Ben Abdessalem](https://twitter.com/LeithBA) - An easy to read transaction history. Shows sales in chronological order.
-
 * [Cryptonoises Bot](https://cryptonoises.com/): Telegram message for sales and collects made by @andriibakulin.
 
-* [Telegram Notifier Bot](https://tzsnt.fr/): Get a telegram message for activity in your wallet.
+* [Token history (open)](https://nftbiker.xyz/history) Retrieve transactions history for a Tezos NFT by [NFTBiker](https://twitter.com/NFTBiker)
 
-* [Token history (open)](https://nftbiker.xyz/history) Retrieve transactions history for a Tezos NFT by [NFTBiker](https://twitter.com/NFTBiker) 
-
-* [Artist summary (open)](https://nftbiker.xyz/artist) by [NFTBiker](https://twitter.com/NFTBiker) 
+* [Artist summary (open)](https://nftbiker.xyz/artist) by [NFTBiker](https://twitter.com/NFTBiker)
 
 * [Secondary market sales on hicdex.com](https://hicdex.com/my-secondary-market-sales)
 
 ***
+
 * [glry.xyz - Collection Appraisal](https://glry.xyz/value)
 
 * [glry.xyz - Capital Gains and Losses](https://glry.xyz/gains) for Hic et Nunc Sales History, Gains and Losses.
 
-* [Audit tool](https://hicetnunc.miketyka.com/audit) by Mike Tyka Audit your creations and collection, see transaction histories. **data seems outdated**
-
-
-
-
-
 ## Giveaway Tools
+
 * [hic et dono](https://dono.xtz.tools/) by [PureSpider](https://twitter.com/PureSpider) - put giveaway OBJKTs up for people to collect only 1 edition per wallet.
 
 * [Giveaway tool](https://nftbiker.xyz/giveaway) by [NFTBiker](https://twitter.com/NFTBiker)  - This tool allow you to transfer 1 edition of a token you own in your wallet to multiples wallets.
-
-
 
 ## Copymint and account restrictions
 
@@ -86,23 +56,13 @@ Due to the open source nature of Teia/hicetnunc, a lot of tools have been build 
 
 ## IPFS Pinning
 
-* [Pinning tool (open)](https://nftbiker.xyz/pin) by [NFTBiker](https://twitter.com/NFTBiker) 
+* [Pinning tool (open)](https://nftbiker.xyz/pin) by [NFTBiker](https://twitter.com/NFTBiker)
 
 * [Hicetnunc IPFS Pinning](https://gist.github.com/mattdesl/47f4ea12ea131eed8401bdacf95a1f47) by Matt DesLauriers
 
 * [Running IPFS node to pin content](https://twitter.com/antic/status/1374417104489697283?s=20) by Adam Eivy
 
-### Shortlink/sharing Services
-
-* [teia.link](https://teia.link/) by [playnft](https://twitter.com/playnft) by 1x1 - using ```http://objkt.link/OBJKTID``` will create a preview with the link on social media and shortens your objkt links (links to teia)
-
-* Share your OBJKT link with image preview on social media, just replace your OBJKT ID by [PureSpider](https://twitter.com/PureSpider) ```http://objkt.link/OBJKTID``` (will link to objkt.com)
-
-* [hetn.xyz](https://hetn.xyz) by [hetn.xyz](https://hetn.xyz) PAID
-
 ## Gallery Tools/Token Viewers
-
-* [Objktiv](https://objktiv.nofungible.cloud/) by [noFungible](https://twitter.com/noFungibleNFT) - Simple, open source, token viewer. Enjoy your digital assets via our hosted instance, or clone it to build your own app!
 
 * [Hexpo](https://hexpo.andreasrau.eu/) by [Andreas Rau](https://twitter.com/andreasrau_eu) - An OBJKT Token gallery tool
 
@@ -111,13 +71,9 @@ Due to the open source nature of Teia/hicetnunc, a lot of tools have been build 
 * [Hic et Nunc API CDK](https://github.com/OrderAndCh4oS/hicetnunc-api-cdk) by [orderandchaos](https://twitter.com/__orderandchaos) (trimmed-down API for fetching wallet and objkt data from the blockchain with conseiljs, intended for use by Galleries.)
 
 * [Generate Thumbs and Upload to S3](https://github.com/OrderAndCh4oS/hicetnunc-generate-thumbs-and-upload-to-s3) By [orderandchaos](https://twitter.com/__orderandchaos)
-This can be combined with Hic et Nunc API CDK to fetch and generate thumbs from a given set of wallet ids and upload them to S3. 
+This can be combined with Hic et Nunc API CDK to fetch and generate thumbs from a given set of wallet ids and upload them to S3.
 
 ***
-
-* [Hen-Gallery](https://hen-gallery.herokuapp.com/) by [PureSpider](https://twitter.com/PureSpider) - A gallery for your OBJKT collection, just connect your wallet. **did not work on check**
-
-* [objkts.gallery](https://objkts.gallery) by @ishacbertran. Creates a beautiful slideshow gallery from a list of OBJKTs. **didnt work on check**
 
 * [Hicetnunc Collection Generator](https://github.com/tarwin/hicetnunc-collection-generator) github by @tarwin generates offline thumbs and a gallery  (Tested only on OSX) **Last update: June 2021**
 
@@ -125,7 +81,7 @@ This can be combined with Hic et Nunc API CDK to fetch and generate thumbs from 
 
 * [Tezos NFT market activity Dashboard](https://public.tableau.com/app/profile/nft.reporter/viz/HENActivityDashboard/Overview) by [Tezos NFT Reporter](https://twitter.com/HENFT_Reporter)
 
-* [Tezos Marketplace Statistics](https://nftbiker.xyz/stats/marketplace?follow=all&type=1) by [NFTBiker](https://twitter.com/NFTBiker) 
+* [Tezos Marketplace Statistics](https://nftbiker.xyz/stats/marketplace?follow=all&type=1) by [NFTBiker](https://twitter.com/NFTBiker) (404 page, maybe it moved?)
 
 ## Open Indexers
 
@@ -134,25 +90,22 @@ This can be combined with Hic et Nunc API CDK to fetch and generate thumbs from 
 * [hicdex](https://hicdex.com/) a blockchain indexer and GraphQL API for hicetnunc by [marchingsquare](https://twitter.com/marchingsquare) **Teia swaps not supported!**
 
 ## Misc
+
 * [ClubNFT backup Tool](https://app.clubnft.com/) - Save the content of all your NFTs on your own harddrive for free. If any of the files get unpinned from IPFS, they can be restored from your backup. [Learn more about how it works here](https://youtu.be/WSs3BhxOo68)
 
 * [Barter Tool](https://barter.nftbiker.xyz/) by [NFTBiker](https://twitter.com/NFTBiker) and [jagracar](https://twitter.com/jagracar) trade NFTs with other NFTs trustlessly.
 
 * [Tax Declaration Software](https://github.com/datcsv/tez-tax) by [datcsv](https://twitter.com/datcsv)
 
-* [redirect browser plugin](https://einaregilsson.com/redirector/) - can be used to change dead mirror links (like hicetnunc.xyz/hicetnunc.art) to funcional ones. for instructions see [sableRaph Tweet](https://twitter.com/sableRaph/status/1524120761539174401?s=20&t=IgL9b5WexlHFxCkGNIBCrQ) - or import this file https://github.com/teia-community/teia-docs/blob/main/DocumentArchive/henmirrorredirector.json
-
-* [TZComet Token Viewer](https://tzcomet.io/#/token/KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton/6291%3Falways-show-multimedia%3Dtrue) a tool to view all metadata and media data of OBJKTs (even banned ones). Simply paste the OBJKTs ID on top right and press Go.
+* [redirect browser plugin](https://einaregilsson.com/redirector/) - can be used to change dead mirror links (like hicetnunc.xyz/hicetnunc.art) to functional ones. for instructions see [sableRaph Tweet](https://twitter.com/sableRaph/status/1524120761539174401?s=20&t=IgL9b5WexlHFxCkGNIBCrQ) - or import this file https://github.com/teia-community/teia-docs/blob/main/DocumentArchive/henmirrorredirector.json
 
 * [Collection grouping tool (OBJKT #59369)](https://www.teia.art/objkt/59369) by [@jagracar](https://twitter.com/jagracar). Groups your collection after artists and highlights copyminted OBJKTs in your (or any) collection
 
 * [Music Album HTML Template](https://teia.art/objkt/25359) by @cryptemes [[github]](https://github.com/EMES77/HEN_MusicAlbum_Template/releases/download/v2.0/CRYPTEMES_HEN_MusicAlbum_Template.zip)
 
-* [Naive status page for hicetnunc.xyz](https://hicetnuncstatus.herokuapp.com/) by @fraguada @LeithBA [github](https://github.com/fraguada/hicetnuncstatus) **hicetnunc.xyz only**
+* [Live feed](https://nftbiker.xyz/live?follow=all) by [NFTBiker](https://twitter.com/NFTBiker)
 
-* [hicetnunc.tools](https://hicetnunc.tools) An unofficial list of community hicetnunc projects. **some seem to be outdated, many dont support Teia swaps**
-
-* [ipfs-lp](https://ipfs-lp.nofungible.cloud/) by [noFungible](https://twitter.com/noFungibleNFT) - Bundle IPFS resources into an interactive album. Release your next LP as a single token!]
+* [Follow Tool](https://nftbiker.xyz/follow) by [NFTBiker](https://twitter.com/NFTBiker)
 
 ## Info for tool builders
 
@@ -160,11 +113,61 @@ Did you develop a tool and want it listed here? Please file an [issue in this re
 
 If your tool relies on older Indexer instances like hicdex.com the new Teia swaps will probably not be available in your tool. You can read more about the [Indexer changes for the Teia swaps](https://github.com/teia-community/teia-docs/wiki/Indexer-changes-for-Teia) and how to make your tools work with teia swaps. Of course, feel free to come to the Teia Discord server to ask questions around tool building and indexing.
 
+## Deprecated or offline tools
+
+Move defunct tools to this section let's remember our fallen comrades.
+
+### Discovery Tools
+
+* [Hen Radio](https://hen.radio/) Browse and enjoy music NFTs minted on Teia/Hicetnunc. By working group 7.2 with [orderandchaos](https://twitter.com/__orderandchaos) , during the first Hicathon. Supports MP3, WAV, and OGG. Can be embedded into any websites.
+
+* [HEO Catalog](https://heo.zmnv.art/) A catalogue of all .glb/.gltf OBJKTs minted on Hicetnunc/Teia
+
+* [random artists](https://henstorefront.xyz/) included in henstorefront.xyz by [homeworkpunks](https://twitter.com/homeworkpunks)
+
+* [Discover OBJKTs by price tiers](https://hicetnunc.miketyka.com) by Mike Tyka **Teia swaps not (yet) supported!**
+
+### Follow / Favourites
+
+* [Henext.xyz](www.henext.xyz) by [xfunct](https://twitter.com/xsfunc) supports following artists
+
+### Selling Tools
+
+* [hictory](https://hictory.glitch.me/) by [Leith Ben Abdessalem](https://twitter.com/LeithBA) - An easy to read transaction history. Shows sales in chronological order.
+
+* [Audit tool](https://hicetnunc.miketyka.com/audit) by Mike Tyka Audit your creations and collection, see transaction histories. **data seems outdated**
 
 
-Not public anymore
-* [Live feed](https://nftbiker.xyz/live?follow=all) by [NFTBiker](https://twitter.com/NFTBiker)
+### Gallery Tools/Token Viewers
 
-* [Follow Tool](https://nftbiker.xyz/follow) by [NFTBiker](https://twitter.com/NFTBiker)  
+* [Objktiv](https://objktiv.nofungible.cloud/) by [noFungible](https://twitter.com/noFungibleNFT) - Simple, open source, token viewer. Enjoy your digital assets via our hosted instance, or clone it to build your own app!
 
+* [Hen-Gallery](https://hen-gallery.herokuapp.com/) by [PureSpider](https://twitter.com/PureSpider) - A gallery for your OBJKT collection, just connect your wallet. **did not work on check**
 
+* [objkts.gallery](https://objkts.gallery) by @ishacbertran. Creates a beautiful slideshow gallery from a list of OBJKTs. **didn't work on check**
+
+### Batch operations (Swap, Cancel, send)
+
+* [Order and Chaos tools](https://tools.orderandchaos.xyz/) — Tool by \[@__orderandchaos\](https://twitter.com/__orderandchaos)
+
+* [batch minting tool](https://henstorefront.xyz/) included in henstorefront.xyz by [homeworkpunks](https://twitter.com/homeworkpunks)
+
+### Shortlink/sharing Services
+
+* [teia.link](https://teia.link/) by [playnft](https://twitter.com/playnft) by 1x1 - using `http://objkt.link/OBJKTID` will create a preview with the link on social media and shortens your objkt links (links to teia)
+
+* Share your OBJKT link with image preview on social media, just replace your OBJKT ID by [PureSpider](https://twitter.com/PureSpider) `http://objkt.link/OBJKTID` (will link to objkt.com)
+
+* [hetn.xyz](https://hetn.xyz) by [hetn.xyz](https://hetn.xyz) PAID
+
+### Misc
+
+* [Naive status page for hicetnunc.xyz](https://hicetnuncstatus.herokuapp.com/) by @fraguada @LeithBA [github](https://github.com/fraguada/hicetnuncstatus) **hicetnunc.xyz only**
+
+* [hicetnunc.tools](https://hicetnunc.tools) An unofficial list of community hicetnunc projects. **some seem to be outdated, many don't support Teia swaps**
+
+* [ipfs-lp](https://ipfs-lp.nofungible.cloud/) by [noFungible](https://twitter.com/noFungibleNFT) - Bundle IPFS resources into an interactive album. Release your next LP as a single token!]
+
+* [TZComet Token Viewer](https://tzcomet.io/#/token/KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton/6291%3Falways-show-multimedia%3Dtrue) a tool to view all metadata and media data of OBJKTs (even banned ones). Simply paste the OBJKTs ID on top right and press Go.
+
+* [Telegram Notifier Bot](https://tzsnt.fr/): Get a telegram message for activity in your wallet.


### PR DESCRIPTION
I was actually wanting to update the General-FAQs.md page, but there was a link from the first question to the Tools-made-by-the-community.md page, and then I started working on that, and it turned out to be a :rabbit: :hole: of broken links and other wondrous things, and now I'm out of time to work on documentation today.  

I moved a lot of defunct stuff down to the bottom and fixed a few typos and trailing spaces.  Didn't add any new links or anything, just trying to tidy up.   