### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue-template.md
@@ -1,0 +1,35 @@
+---
+name: Documentation Issue Template
+about: Report an issue or suggest an improvement for the Teia community documentation.
+title: "[Teia-Docs] (Your Documentation Issue Title Here)"
+labels: documentation
+assignees: ''
+
+---
+
+## 🚫 Before You File This Issue
+
+This repository is **only for issues about the Teia community documentation** at [docs.teia.art](https://docs.teia.art).
+
+**✅ Use this repo for:**
+- Typos or grammar fixes in the docs
+- Outdated or missing information
+- Suggestions for improving documentation
+
+**❌ Do NOT use this repo for:**
+- Bugs or feature requests about the [teia.art](https://teia.art) site itself
+- Anything related to the Teia user interface, wallet integration, or artwork display
+
+If your issue is about the **Teia site (teia.art)**, please file it here instead:  
+👉 [Teia-UI Issues](https://github.com/teia-community/teia-ui/issues)
+
+---
+
+### Describe the documentation issue
+<!-- Clearly describe the problem with the documentation -->
+
+### Link to the affected page (if applicable)
+<!-- Paste the full URL of the page on docs.teia.art -->
+
+### Proposed fix or improvement
+<!-- Optional: Suggest how the documentation could be improved -->


### PR DESCRIPTION
Add a docs issue template.  

In the past I can see some users wandered in here and opened an issue regarding the Teia-UI repo/Teia.art site.  This should help deal with that confusion and allow us to keep an issue queue so people can come and raise issue about the documentation like typos or out of date information and to suggest new documentation pages that we might want to add. 