### PR TITLE
Disable blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Teia-UI Issues
+    url: https://github.com/teia-community/teia-ui/issues
+    about: Report bugs or request features for the Teia site (teia.art)


### PR DESCRIPTION
There has been some confusion in the past about opening issues here.  This repo is for the documentation site, not the Teia.art/teia-ui repo.   This config will disable the "blank issue template" so that when users try to open a issue in the docs repo, they will see the template with instructions about going to the teia-ui repo if there issue is about Teia.art rather than something about the docs.  

Follow up on #19 where the docs template was added.  Just some admin stuff, no code review needed.