### PR TITLE
Fix deployment trigger so workflow only runs on changes that need to be deployed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
-name: Deploy to GitHub Pages
+name: Deploy teia-docs site to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: # deploy only if Docusaurus site updated
+      - 'teia-docs/**'
+      - '.github/workflows/deploy.yml'
+    workflow_dispatch: # enables manual runs if needed
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes the workflow trigger so that GitHub Pages is only deployed when changes are made to the teia-docs folder.

Closes #22.

@Zir0h FYI