### PR TITLE
Roll back to before CNAME change state

### DIFF
--- a/teia-docs/docusaurus.config.ts
+++ b/teia-docs/docusaurus.config.ts
@@ -15,12 +15,10 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://docs.teia.art',
+  url: 'https://teia-community.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  // We want the docs at the root of the domain to avoid something like:
-  // https//docs.teia.art/teia-docs/blah
-  baseUrl: '/',
+  baseUrl: '/teia-docs/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Looks like we will need to make the CNAME change before some final config tweaks to get the site working on the Custom domain. 

```
floyd @明道 ❯ gh api --method PUT \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  repos/teia-community/teia-docs/pages \
  -f cname=docs.teia.art \
  -F https_enforced=true
{
  "message": "The certificate does not exist yet",
  "documentation_url": "https://docs.github.com/rest/pages/pages#update-information-about-a-apiname-pages-site",
  "status": "404"
}
gh: The certificate does not exist yet (HTTP 404)
```

Potentially we can set the "https_enforced" to false while we wait, but will coordinate that change first.