### PR TITLE
Config changes we can make prior to dns change

### DIFF
--- a/teia-docs/docusaurus.config.ts
+++ b/teia-docs/docusaurus.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://teia-community.github.io',
+  url: 'https://docs.teia.art',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/teia-docs/',

--- a/teia-docs/static/CNAME
+++ b/teia-docs/static/CNAME
@@ -1,0 +1,1 @@
+docs.teia.art


### PR DESCRIPTION
I think these should be safe to deploy before the change.  

A follow up can be done to remove the "teia-docs" segment in the url after the custom domain is setup. 