### PR TITLE
Docusaurus config change after CNAME change and GitHub pages custom domain set

### DIFF
--- a/teia-docs/docusaurus.config.ts
+++ b/teia-docs/docusaurus.config.ts
@@ -15,10 +15,11 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://teia-community.github.io',
+  url: 'https://docs.teia.art',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/teia-docs/',
+  // Mount the docs at the domain root while keeping redirects in place.
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/teia-docs/static/CNAME
+++ b/teia-docs/static/CNAME
@@ -1,0 +1,1 @@
+docs.teia.art


### PR DESCRIPTION
This will set the Docusaurus config to use the custom domain once the DNS change has been made, and the GitHub pages custom domain setting has been set.   Needs these 3 steps apparently to work.

See issue #35 Once those changes have been change there, merge this to main.