### PR TITLE
Fix up some borked links

### DIFF
--- a/teia-docs/docs/Core-Values-Code-of-Conduct-Terms-and-Conditions.md
+++ b/teia-docs/docs/Core-Values-Code-of-Conduct-Terms-and-Conditions.md
@@ -107,18 +107,20 @@ We want Teia to be a safe and productive environment for everyone. This Code of 
 
 As artists and collectors of art, we want to acknowledge and protect intellectual property as it is crucial for our integrity and work but we also acknowledge that some forms of art need to use the works of others (i.e. remixes, tributes, quotes).
 
-- Artists should avoid uses of existing copyrighted material that do not generate new artistic meaning, being aware that a change of medium, without more, may not meet this standard. [[src]](#cc-annex)
+- Artists should avoid uses of existing copyrighted material that do not generate new artistic meaning, being aware that a change of medium, without more, may not meet this standard. [src](#cc-annex)
 
-- The use of a preexisting work, whether in part or in whole, should be justified by the artistic objective, and artists who deliberately repurpose copyrighted works should be prepared to explain their rationales both for doing so and for the extent of their uses. [[src]](#cc-annex)
+- The use of a preexisting work, whether in part or in whole, should be justified by the artistic objective, and artists who deliberately repurpose copyrighted works should be prepared to explain their rationales both for doing so and for the extent of their uses. [src](#cc-annex)
 
-- Artists should avoid suggesting that incorporated elements are original to them, unless that suggestion is integral to the meaning of the new work. [[src]](#cc-annex)
+- Artists should avoid suggesting that incorporated elements are original to them, unless that suggestion is integral to the meaning of the new work. [src](#cc-annex)
 
 - We suggest not to mint content that is in the public domain or under other similar licenses that allow reselling without creative changes or using it as a way of artistic expression.  
 While some content is free to be used and if specified in the license even commercially, there are problematic implications that come with minting unchanged content and selling it as a NFT, such as occurring double mints if multiple people mint the same public domain content (see [Terms & Conditions](#reasons-for-an-account-restrictionreview)). 
 
 - When creating a homage piece to somebody else’s work, an artist should seek consent from the creator of the original, clearly label it as a homage and name the original creator, unless there is an articulable aesthetic basis for not doing so (i.e. pastiche / sampling / collage / satire etc).
 
-<a name="cc-annex">[src]</a> see page 11 of [Digital Commons](https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1000&context=scholcom)
+#### Reference {#cc-annex}
+
+[src] see page 11 of [Digital Commons](https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1000&context=scholcom)
 
 
 ### Fair play on the marketplace

--- a/teia-docs/docs/dev-howtos/How-to-set-up-a-Teia-Mirror.md
+++ b/teia-docs/docs/dev-howtos/How-to-set-up-a-Teia-Mirror.md
@@ -41,7 +41,7 @@ _by NFTBiker & mel_
 
 ### Requirements:
 
-- [Github](https://github.com/) Account (not mandatory for Vercel, see [Vercel (local)](#Vercel))
+- [Github](https://github.com/) Account (not mandatory for Vercel, see [Vercel (local)](#vercel-local))
 - Either a [Netlify](https://www.netlify.com/), [Cloudflare](https://www.cloudflare.com) or [Vercel](https://vercel.com/) free deployment account.
 - A [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of [teia-ui](https://github.com/teia-community/teia-ui)'s repository in your own Github account
 


### PR DESCRIPTION
Fixes some broken links the Docusaurus build complained about: 

```
Run npm run build
> teia-docs@0.0.0 build
> docusaurus build
[INFO] [en] Creating an optimized production build...
[info] [webpackbar] Compiling Client
[info] [webpackbar] Compiling Server
[success] [webpackbar] Server: Compiled successfully in 18.56s
[success] [webpackbar] Client: Compiled successfully in 26.78s
Warning:  Docusaurus found broken anchors!
Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.
Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /core-values-code-of-conduct-terms-and-conditions:
   -> linking to #cc-annex (resolved as: /core-values-code-of-conduct-terms-and-conditions#cc-annex)
- Broken anchor on source page path = /dev-howtos/how-to-set-up-a-teia-mirror:
   -> linking to #Vercel (resolved as: /dev-howtos/how-to-set-up-a-teia-mirror#Vercel)
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```

Just fixing bugs, no review needed.