### PR TITLE
[Feature] Add an admonition box to the core values page

### DIFF
--- a/teia-docs/docs/Core-Values-Code-of-Conduct-Terms-and-Conditions.md
+++ b/teia-docs/docs/Core-Values-Code-of-Conduct-Terms-and-Conditions.md
@@ -4,10 +4,13 @@ title: Core Values, Code of Conduct & Terms and Conditions
 sidebar_label: Core Values, Code of Conduct & Terms and Conditions
 ---
 
-These documents were drafted during the hic et nunc hicathon and got worked on since then by the Teia community. 
-Those are “living documents” that have not been voted on yet and will be subject to changes made by the "core values" working group of the teia community until finalized by an official vote. However they are put in place until consensus is reached as they reflect the current state of the discussion and are the result of a wide and long process with diverse contributors.
+:::info[Living document]
 
-If you want to add ideas/feedback - go to the #core-values-philosophy channel on the [Teia Discord](https://discord.gg/ueU7cVBF) and bring your input there!
+These documents were drafted during the hic et nunc hicathon and have been refined by the Teia community. They are “living documents” that have not been voted on yet and will be updated by the "core values" working group until finalized by an official vote. They reflect the current state of the discussion and result from a wide and long process with diverse contributors.
+
+If you want to add ideas or feedback, go to the #core-values-philosophy channel on the [Teia Discord](https://discord.gg/ueU7cVBF) and bring your input there!
+
+:::
 
 
 **Table of Contents**


### PR DESCRIPTION
Per this issue #41 I just wanted to pop out the bit of text at the top of the "Core Values" page because it's not part of the text, it's describing how the text was created and what it is.  What Docusaurus calls an admonition.  I've tested locally, for some reason my fork can't render but locally the change looks like the screen shot: 

<img width="1312" height="1100" alt="Screenshot From 2025-12-09 22-53-26" src="https://github.com/user-attachments/assets/50f36d34-f0a2-4e7a-a351-cb3ebd541fbe" />

So, it's just adding a text box feature to that first bit of text in the document which separates it from the main text, as I think it should be.   I thought about rewriting the text a bit, but these leaves it as it was imported from the wiki, just adding a design feature here.