### PR TITLE
Update upload-pages-artifact action

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm run build
 
       - name: Upload built site
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: teia-docs/build
 


### PR DESCRIPTION
- Fixed GitHub Actions Node.js 24 warning: updated `actions/upload-pages-artifact` from v3 to v4 (other actions already v4 which supports Node 24)